### PR TITLE
feat(symbolic): k-induction, IC3/CHC, smart mode, set ops, strings, traces

### DIFF
--- a/specl/Cargo.lock
+++ b/specl/Cargo.lock
@@ -2301,10 +2301,12 @@ version = "0.1.0"
 dependencies = [
  "specl-eval",
  "specl-ir",
+ "specl-syntax",
  "specl-types",
  "thiserror 1.0.69",
  "tracing",
  "z3",
+ "z3-sys",
 ]
 
 [[package]]

--- a/specl/crates/specl-symbolic/Cargo.toml
+++ b/specl/crates/specl-symbolic/Cargo.toml
@@ -11,6 +11,8 @@ description = "Symbolic model checking backend for Specl using Z3"
 specl-ir.workspace = true
 specl-types.workspace = true
 specl-eval.workspace = true
+specl-syntax.workspace = true
 z3 = { version = "0.19", features = ["bundled"] }
+z3-sys = "0.10.4"
 thiserror.workspace = true
 tracing.workspace = true

--- a/specl/crates/specl-symbolic/src/bmc.rs
+++ b/specl/crates/specl-symbolic/src/bmc.rs
@@ -18,7 +18,7 @@ pub fn check_bmc(
 ) -> SymbolicResult<SymbolicOutcome> {
     info!(depth = max_depth, "starting symbolic BMC");
 
-    let layout = VarLayout::from_spec(spec)?;
+    let layout = VarLayout::from_spec(spec, consts)?;
     let solver = Solver::new();
 
     // Create Z3 variables for steps 0..=max_depth

--- a/specl/crates/specl-symbolic/src/fixedpoint.rs
+++ b/specl/crates/specl-symbolic/src/fixedpoint.rs
@@ -1,0 +1,66 @@
+//! Minimal safe wrapper around z3-sys fixedpoint (Spacer/IC3) API.
+
+use z3::Context;
+
+/// Wrapper around Z3 fixedpoint engine (Spacer).
+pub struct Fixedpoint {
+    ctx: z3_sys::Z3_context,
+    fp: z3_sys::Z3_fixedpoint,
+}
+
+impl Fixedpoint {
+    /// Create a new fixedpoint engine using the thread-local Z3 context.
+    pub fn new() -> Self {
+        let ctx = Context::thread_local().get_z3_context();
+        let fp = unsafe { z3_sys::Z3_mk_fixedpoint(ctx) }.unwrap();
+        unsafe { z3_sys::Z3_fixedpoint_inc_ref(ctx, fp) };
+
+        // Set engine to spacer (IC3)
+        let params = unsafe { z3_sys::Z3_mk_params(ctx) }.unwrap();
+        unsafe { z3_sys::Z3_params_inc_ref(ctx, params) };
+        let key =
+            unsafe { z3_sys::Z3_mk_string_symbol(ctx, b"engine\0".as_ptr() as *const _) }.unwrap();
+        let val =
+            unsafe { z3_sys::Z3_mk_string_symbol(ctx, b"spacer\0".as_ptr() as *const _) }.unwrap();
+        unsafe { z3_sys::Z3_params_set_symbol(ctx, params, key, val) };
+        unsafe { z3_sys::Z3_fixedpoint_set_params(ctx, fp, params) };
+        unsafe { z3_sys::Z3_params_dec_ref(ctx, params) };
+
+        Fixedpoint { ctx, fp }
+    }
+
+    /// Register a relation (func_decl) with the fixedpoint engine.
+    pub fn register_relation(&self, func_decl: z3_sys::Z3_func_decl) {
+        unsafe { z3_sys::Z3_fixedpoint_register_relation(self.ctx, self.fp, func_decl) };
+    }
+
+    /// Add a rule (universally quantified Horn clause).
+    pub fn add_rule(&self, rule: z3_sys::Z3_ast) {
+        let name = unsafe { z3_sys::Z3_mk_string_symbol(self.ctx, b"rule\0".as_ptr() as *const _) }
+            .unwrap();
+        unsafe { z3_sys::Z3_fixedpoint_add_rule(self.ctx, self.fp, rule, name) };
+    }
+
+    /// Query whether the given relation is reachable. Returns Z3_lbool.
+    pub fn query(&self, query: z3_sys::Z3_ast) -> z3_sys::Z3_lbool {
+        unsafe { z3_sys::Z3_fixedpoint_query(self.ctx, self.fp, query) }
+    }
+
+    /// Get the reason for an unknown result.
+    pub fn get_reason_unknown(&self) -> String {
+        let s = unsafe { z3_sys::Z3_fixedpoint_get_reason_unknown(self.ctx, self.fp) };
+        if s.is_null() {
+            return "(null)".to_string();
+        }
+        unsafe { std::ffi::CStr::from_ptr(s) }
+            .to_str()
+            .unwrap_or("(invalid utf8)")
+            .to_string()
+    }
+}
+
+impl Drop for Fixedpoint {
+    fn drop(&mut self) {
+        unsafe { z3_sys::Z3_fixedpoint_dec_ref(self.ctx, self.fp) };
+    }
+}

--- a/specl/crates/specl-symbolic/src/ic3.rs
+++ b/specl/crates/specl-symbolic/src/ic3.rs
@@ -1,0 +1,281 @@
+//! IC3/CHC verification via Z3's Spacer engine.
+//!
+//! Encodes the spec as Constrained Horn Clauses and uses Z3's fixedpoint
+//! engine (Spacer) to perform unbounded verification.
+
+use crate::encoder::{assert_range_constraints, create_step_vars, EncoderCtx};
+use crate::fixedpoint::Fixedpoint;
+use crate::state_vars::{VarKind, VarLayout};
+use crate::transition::{encode_init, encode_transition};
+use crate::{SymbolicOutcome, SymbolicResult};
+use specl_eval::Value;
+use specl_ir::CompiledSpec;
+use tracing::info;
+use z3::ast::{Ast, Dynamic};
+use z3::{Context, Solver};
+
+/// Run IC3/CHC verification using Z3's Spacer engine.
+pub fn check_ic3(spec: &CompiledSpec, consts: &[Value]) -> SymbolicResult<SymbolicOutcome> {
+    info!("starting IC3/CHC verification");
+
+    let layout = VarLayout::from_spec(spec, consts)?;
+    let ctx = Context::thread_local().get_z3_context();
+    let fp = Fixedpoint::new();
+
+    // Collect sorts for all flattened state variables
+    let sorts = collect_sorts(&layout, ctx);
+    let num_vars = sorts.len();
+
+    // Declare Reach relation
+    let reach_name =
+        unsafe { z3_sys::Z3_mk_string_symbol(ctx, b"Reach\0".as_ptr() as *const _) }.unwrap();
+    let bool_sort = unsafe { z3_sys::Z3_mk_bool_sort(ctx) }.unwrap();
+    let reach_decl = unsafe {
+        z3_sys::Z3_mk_func_decl(ctx, reach_name, num_vars as u32, sorts.as_ptr(), bool_sort)
+    }
+    .unwrap();
+    fp.register_relation(reach_decl);
+
+    // Create step vars for step 0 and step 1
+    let step0_vars = create_step_vars(&layout, 0);
+    let step1_vars = create_step_vars(&layout, 1);
+    let all_step_vars = vec![step0_vars, step1_vars];
+
+    // Collect all Z3 constants (as Z3_app) for quantification
+    let flat0 = flatten_step_vars(&all_step_vars[0]);
+    let flat1 = flatten_step_vars(&all_step_vars[1]);
+    let apps0 = to_apps(ctx, &flat0);
+    let apps1 = to_apps(ctx, &flat1);
+    let all_apps: Vec<z3_sys::Z3_app> = apps0.iter().chain(apps1.iter()).copied().collect();
+
+    let reach_0 = mk_app(ctx, reach_decl, &flat0);
+    let reach_1 = mk_app(ctx, reach_decl, &flat1);
+
+    // === Init rule: forall vars0. init(vars0) => Reach(vars0) ===
+    let init_solver = Solver::new();
+    assert_range_constraints(&init_solver, &layout, &all_step_vars, 0);
+    encode_init(&init_solver, spec, consts, &layout, &all_step_vars)?;
+    let init_formula = solver_conjunction_raw(ctx, &init_solver);
+    let init_body = mk_implies(ctx, init_formula, reach_0);
+    let init_rule = mk_forall(ctx, &apps0, init_body);
+    fp.add_rule(init_rule);
+
+    // === Transition rule: forall vars0,vars1. Reach(vars0) ∧ range(vars1) ∧ trans => Reach(vars1) ===
+    let trans = encode_transition(spec, consts, &layout, &all_step_vars, 0)?;
+    let trans_raw = trans.get_z3_ast();
+    inc_ref(ctx, trans_raw);
+
+    let range_solver = Solver::new();
+    assert_range_constraints(&range_solver, &layout, &all_step_vars, 1);
+    let range_formula = solver_conjunction_raw(ctx, &range_solver);
+
+    let trans_body = mk_and3(ctx, reach_0, range_formula, trans_raw);
+    let trans_impl = mk_implies(ctx, trans_body, reach_1);
+    let trans_rule = mk_forall(ctx, &all_apps, trans_impl);
+    fp.add_rule(trans_rule);
+
+    // === Query each invariant ===
+    // Use Error relation pattern: Reach(vars) ∧ ¬inv(vars) => Error
+    let err_name =
+        unsafe { z3_sys::Z3_mk_string_symbol(ctx, b"Error\0".as_ptr() as *const _) }.unwrap();
+    let err_decl =
+        unsafe { z3_sys::Z3_mk_func_decl(ctx, err_name, 0, std::ptr::null(), bool_sort) }.unwrap();
+    fp.register_relation(err_decl);
+    let err_app = mk_app(ctx, err_decl, &[]);
+
+    for inv in &spec.invariants {
+        let mut enc = EncoderCtx {
+            layout: &layout,
+            consts,
+            step_vars: &all_step_vars,
+            current_step: 0,
+            next_step: 0,
+            params: &[],
+            locals: Vec::new(),
+        };
+        let inv_encoded = enc.encode_bool(&inv.body)?;
+        let inv_raw = inv_encoded.get_z3_ast();
+        inc_ref(ctx, inv_raw);
+        let neg_inv_raw = mk_not(ctx, inv_raw);
+
+        // Rule: forall vars0. Reach(vars0) ∧ ¬I(vars0) => Error
+        let err_body = mk_and2(ctx, reach_0, neg_inv_raw);
+        let err_impl = mk_implies(ctx, err_body, err_app);
+        let err_rule = mk_forall(ctx, &apps0, err_impl);
+        fp.add_rule(err_rule);
+
+        match fp.query(err_app) {
+            z3_sys::Z3_L_FALSE => {
+                info!(invariant = inv.name, "invariant verified by IC3");
+            }
+            z3_sys::Z3_L_TRUE => {
+                info!(invariant = inv.name, "IC3 found invariant violation");
+                return Ok(SymbolicOutcome::InvariantViolation {
+                    invariant: inv.name.clone(),
+                    trace: Vec::new(),
+                });
+            }
+            _ => {
+                let reason = fp.get_reason_unknown();
+                info!(
+                    invariant = inv.name,
+                    reason = reason,
+                    "IC3 returned unknown"
+                );
+                return Ok(SymbolicOutcome::Unknown {
+                    reason: format!(
+                        "IC3 returned unknown for invariant '{}': {}",
+                        inv.name, reason
+                    ),
+                });
+            }
+        }
+    }
+
+    info!("all invariants verified by IC3");
+    Ok(SymbolicOutcome::Ok { method: "IC3" })
+}
+
+// === Raw z3-sys helper functions ===
+// All helpers inc_ref their return values to prevent Z3 GC.
+
+fn inc_ref(ctx: z3_sys::Z3_context, ast: z3_sys::Z3_ast) {
+    unsafe { z3_sys::Z3_inc_ref(ctx, ast) };
+}
+
+fn mk_implies(ctx: z3_sys::Z3_context, a: z3_sys::Z3_ast, b: z3_sys::Z3_ast) -> z3_sys::Z3_ast {
+    let r = unsafe { z3_sys::Z3_mk_implies(ctx, a, b) }.unwrap();
+    inc_ref(ctx, r);
+    r
+}
+
+fn mk_not(ctx: z3_sys::Z3_context, a: z3_sys::Z3_ast) -> z3_sys::Z3_ast {
+    let r = unsafe { z3_sys::Z3_mk_not(ctx, a) }.unwrap();
+    inc_ref(ctx, r);
+    r
+}
+
+fn mk_and2(ctx: z3_sys::Z3_context, a: z3_sys::Z3_ast, b: z3_sys::Z3_ast) -> z3_sys::Z3_ast {
+    let args = [a, b];
+    let r = unsafe { z3_sys::Z3_mk_and(ctx, 2, args.as_ptr()) }.unwrap();
+    inc_ref(ctx, r);
+    r
+}
+
+fn mk_and3(
+    ctx: z3_sys::Z3_context,
+    a: z3_sys::Z3_ast,
+    b: z3_sys::Z3_ast,
+    c: z3_sys::Z3_ast,
+) -> z3_sys::Z3_ast {
+    let args = [a, b, c];
+    let r = unsafe { z3_sys::Z3_mk_and(ctx, 3, args.as_ptr()) }.unwrap();
+    inc_ref(ctx, r);
+    r
+}
+
+fn mk_app(
+    ctx: z3_sys::Z3_context,
+    decl: z3_sys::Z3_func_decl,
+    args: &[z3_sys::Z3_ast],
+) -> z3_sys::Z3_ast {
+    let r = unsafe { z3_sys::Z3_mk_app(ctx, decl, args.len() as u32, args.as_ptr()) }.unwrap();
+    inc_ref(ctx, r);
+    r
+}
+
+fn mk_forall(
+    ctx: z3_sys::Z3_context,
+    apps: &[z3_sys::Z3_app],
+    body: z3_sys::Z3_ast,
+) -> z3_sys::Z3_ast {
+    if apps.is_empty() {
+        return body;
+    }
+    let r = unsafe {
+        z3_sys::Z3_mk_forall_const(
+            ctx,
+            0, // weight
+            apps.len() as u32,
+            apps.as_ptr(),
+            0, // num_patterns
+            std::ptr::null(),
+            body,
+        )
+    }
+    .unwrap();
+    inc_ref(ctx, r);
+    r
+}
+
+/// Convert Z3_ast constants to Z3_app for quantifier binding.
+fn to_apps(ctx: z3_sys::Z3_context, asts: &[z3_sys::Z3_ast]) -> Vec<z3_sys::Z3_app> {
+    asts.iter()
+        .map(|a| unsafe { z3_sys::Z3_to_app(ctx, *a) }.unwrap())
+        .collect()
+}
+
+/// Extract all solver assertions as a raw Z3_ast conjunction.
+/// The returned AST is ref-counted (inc_ref called).
+fn solver_conjunction_raw(ctx: z3_sys::Z3_context, solver: &Solver) -> z3_sys::Z3_ast {
+    let assertions = solver.get_assertions();
+    if assertions.is_empty() {
+        let t = unsafe { z3_sys::Z3_mk_true(ctx) }.unwrap();
+        inc_ref(ctx, t);
+        return t;
+    }
+    let raw: Vec<z3_sys::Z3_ast> = assertions.iter().map(|a| a.get_z3_ast()).collect();
+    let result = if raw.len() == 1 {
+        raw[0]
+    } else {
+        unsafe { z3_sys::Z3_mk_and(ctx, raw.len() as u32, raw.as_ptr()) }.unwrap()
+    };
+    inc_ref(ctx, result);
+    result
+}
+
+/// Collect Z3 sorts for all flattened state variables.
+fn collect_sorts(layout: &VarLayout, ctx: z3_sys::Z3_context) -> Vec<z3_sys::Z3_sort> {
+    let bool_sort = unsafe { z3_sys::Z3_mk_bool_sort(ctx) }.unwrap();
+    let int_sort = unsafe { z3_sys::Z3_mk_int_sort(ctx) }.unwrap();
+
+    let mut sorts = Vec::new();
+    for entry in &layout.entries {
+        collect_sorts_for_kind(&entry.kind, bool_sort, int_sort, &mut sorts);
+    }
+    sorts
+}
+
+fn collect_sorts_for_kind(
+    kind: &VarKind,
+    bool_sort: z3_sys::Z3_sort,
+    int_sort: z3_sys::Z3_sort,
+    out: &mut Vec<z3_sys::Z3_sort>,
+) {
+    match kind {
+        VarKind::Bool => out.push(bool_sort),
+        VarKind::Int { .. } => out.push(int_sort),
+        VarKind::ExplodedDict {
+            key_lo,
+            key_hi,
+            value_kind,
+        } => {
+            for _ in 0..(*key_hi - *key_lo + 1) {
+                collect_sorts_for_kind(value_kind, bool_sort, int_sort, out);
+            }
+        }
+        VarKind::ExplodedSet { lo, hi } => {
+            for _ in 0..(*hi - *lo + 1) {
+                out.push(bool_sort);
+            }
+        }
+    }
+}
+
+/// Flatten step vars into a single vec of raw Z3 ASTs.
+fn flatten_step_vars(step_vars: &[Vec<Dynamic>]) -> Vec<z3_sys::Z3_ast> {
+    step_vars
+        .iter()
+        .flat_map(|vs| vs.iter().map(|v| v.get_z3_ast()))
+        .collect()
+}

--- a/specl/crates/specl-symbolic/src/inductive.rs
+++ b/specl/crates/specl-symbolic/src/inductive.rs
@@ -20,7 +20,7 @@ use z3::{SatResult, Solver};
 pub fn check_inductive(spec: &CompiledSpec, consts: &[Value]) -> SymbolicResult<SymbolicOutcome> {
     info!("starting inductive invariant checking");
 
-    let layout = VarLayout::from_spec(spec)?;
+    let layout = VarLayout::from_spec(spec, consts)?;
     let solver = Solver::new();
 
     let step0_vars = create_step_vars(&layout, 0);

--- a/specl/crates/specl-symbolic/src/k_induction.rs
+++ b/specl/crates/specl-symbolic/src/k_induction.rs
@@ -1,0 +1,197 @@
+//! k-induction: strictly more powerful than simple induction.
+//!
+//! For each invariant I, checks two conditions:
+//!   Base case: BMC to depth K finds no violation (init + transitions + ¬I is UNSAT for all steps)
+//!   Inductive step: K+1 consecutive states where I holds for the first K,
+//!     transitions hold between all, and ¬I at step K — must be UNSAT.
+//!
+//! Both UNSAT → proven for all reachable states.
+
+use crate::encoder::{assert_range_constraints, create_step_vars, EncoderCtx};
+use crate::state_vars::VarLayout;
+use crate::trace::extract_trace;
+use crate::transition::{encode_init, encode_transition};
+use crate::{SymbolicOutcome, SymbolicResult};
+use specl_eval::Value;
+use specl_ir::CompiledSpec;
+use tracing::info;
+use z3::{SatResult, Solver};
+
+/// Run k-induction checking with the given strengthening depth.
+pub fn check_k_induction(
+    spec: &CompiledSpec,
+    consts: &[Value],
+    k: usize,
+) -> SymbolicResult<SymbolicOutcome> {
+    info!(k, "starting k-induction");
+
+    let layout = VarLayout::from_spec(spec, consts)?;
+
+    // === Base case: BMC to depth K ===
+    info!(k, "k-induction base case");
+    if let Some(outcome) = check_base_case(spec, consts, &layout, k)? {
+        return Ok(outcome);
+    }
+
+    // === Inductive step ===
+    info!(k, "k-induction inductive step");
+    check_inductive_step(spec, consts, &layout, k)
+}
+
+/// Base case: init + transitions for K steps, check ¬I at each step.
+fn check_base_case(
+    spec: &CompiledSpec,
+    consts: &[Value],
+    layout: &VarLayout,
+    k: usize,
+) -> SymbolicResult<Option<SymbolicOutcome>> {
+    let solver = Solver::new();
+
+    let mut all_step_vars = Vec::new();
+    for step in 0..=k {
+        all_step_vars.push(create_step_vars(layout, step));
+    }
+
+    for step in 0..=k {
+        assert_range_constraints(&solver, layout, &all_step_vars, step);
+    }
+
+    encode_init(&solver, spec, consts, layout, &all_step_vars)?;
+
+    for depth in 0..=k {
+        if depth > 0 {
+            let trans = encode_transition(spec, consts, layout, &all_step_vars, depth - 1)?;
+            solver.assert(&trans);
+        }
+
+        for inv in &spec.invariants {
+            solver.push();
+
+            let mut enc = EncoderCtx {
+                layout,
+                consts,
+                step_vars: &all_step_vars,
+                current_step: depth,
+                next_step: depth,
+                params: &[],
+                locals: Vec::new(),
+            };
+            let inv_encoded = enc.encode_bool(&inv.body)?;
+            solver.assert(&inv_encoded.not());
+
+            match solver.check() {
+                SatResult::Sat => {
+                    info!(invariant = inv.name, depth, "base case violation found");
+                    let model = solver.get_model().unwrap();
+                    let trace = extract_trace(&model, layout, &all_step_vars, spec, consts, depth);
+                    return Ok(Some(SymbolicOutcome::InvariantViolation {
+                        invariant: inv.name.clone(),
+                        trace,
+                    }));
+                }
+                SatResult::Unsat => {}
+                SatResult::Unknown => {
+                    solver.pop(1);
+                    return Ok(Some(SymbolicOutcome::Unknown {
+                        reason: format!(
+                            "Z3 returned unknown at base depth {} for invariant '{}'",
+                            depth, inv.name
+                        ),
+                    }));
+                }
+            }
+
+            solver.pop(1);
+        }
+    }
+
+    Ok(None)
+}
+
+/// Inductive step: K+1 states (0..=K), assert I at 0..K-1, transitions, ¬I at K.
+fn check_inductive_step(
+    spec: &CompiledSpec,
+    consts: &[Value],
+    layout: &VarLayout,
+    k: usize,
+) -> SymbolicResult<SymbolicOutcome> {
+    let solver = Solver::new();
+
+    // K+1 states: 0..=K
+    let mut all_step_vars = Vec::new();
+    for step in 0..=k {
+        all_step_vars.push(create_step_vars(layout, step));
+    }
+
+    for step in 0..=k {
+        assert_range_constraints(&solver, layout, &all_step_vars, step);
+    }
+
+    // Assert transitions between all consecutive pairs
+    for step in 0..k {
+        let trans = encode_transition(spec, consts, layout, &all_step_vars, step)?;
+        solver.assert(&trans);
+    }
+
+    for inv in &spec.invariants {
+        solver.push();
+
+        // Assert I(s_0), ..., I(s_{K-1})
+        for step in 0..k {
+            let mut enc = EncoderCtx {
+                layout,
+                consts,
+                step_vars: &all_step_vars,
+                current_step: step,
+                next_step: step,
+                params: &[],
+                locals: Vec::new(),
+            };
+            let inv_at_step = enc.encode_bool(&inv.body)?;
+            solver.assert(&inv_at_step);
+        }
+
+        // Assert ¬I(s_K)
+        let mut enc_k = EncoderCtx {
+            layout,
+            consts,
+            step_vars: &all_step_vars,
+            current_step: k,
+            next_step: k,
+            params: &[],
+            locals: Vec::new(),
+        };
+        let inv_at_k = enc_k.encode_bool(&inv.body)?;
+        solver.assert(&inv_at_k.not());
+
+        match solver.check() {
+            SatResult::Sat => {
+                // CTI (counterexample to induction) — not a real bug, just not provable at K
+                info!(invariant = inv.name, k, "inductive step failed (CTI)");
+                solver.pop(1);
+                return Ok(SymbolicOutcome::Unknown {
+                    reason: format!("invariant '{}' not k-inductive at k={}", inv.name, k),
+                });
+            }
+            SatResult::Unsat => {
+                info!(invariant = inv.name, k, "invariant is k-inductive");
+            }
+            SatResult::Unknown => {
+                solver.pop(1);
+                return Ok(SymbolicOutcome::Unknown {
+                    reason: format!(
+                        "Z3 returned unknown for k-induction step for invariant '{}'",
+                        inv.name
+                    ),
+                });
+            }
+        }
+
+        solver.pop(1);
+    }
+
+    info!(k, "all invariants are k-inductive");
+    Ok(SymbolicOutcome::Ok {
+        method: "k-induction",
+    })
+}

--- a/specl/crates/specl-symbolic/src/lib.rs
+++ b/specl/crates/specl-symbolic/src/lib.rs
@@ -5,7 +5,11 @@
 
 pub mod bmc;
 pub mod encoder;
+pub mod fixedpoint;
+pub mod ic3;
 pub mod inductive;
+pub mod k_induction;
+pub mod smart;
 pub mod state_vars;
 pub mod trace;
 pub mod transition;
@@ -69,6 +73,12 @@ pub enum SymbolicMode {
     Bmc,
     /// Inductive invariant checking: single-step proof.
     Inductive,
+    /// k-induction with given strengthening depth.
+    KInduction(usize),
+    /// IC3/CHC via Z3's Spacer engine (unbounded verification).
+    Ic3,
+    /// Smart mode: automatic strategy cascade.
+    Smart,
 }
 
 /// Run symbolic model checking on a compiled spec.
@@ -80,5 +90,8 @@ pub fn check(
     match config.mode {
         SymbolicMode::Bmc => bmc::check_bmc(spec, consts, config.depth),
         SymbolicMode::Inductive => inductive::check_inductive(spec, consts),
+        SymbolicMode::KInduction(k) => k_induction::check_k_induction(spec, consts, k),
+        SymbolicMode::Ic3 => ic3::check_ic3(spec, consts),
+        SymbolicMode::Smart => smart::check_smart(spec, consts, config.depth),
     }
 }

--- a/specl/crates/specl-symbolic/src/smart.rs
+++ b/specl/crates/specl-symbolic/src/smart.rs
@@ -1,0 +1,80 @@
+//! Smart mode: automatic strategy cascade for symbolic verification.
+//!
+//! Tries progressively stronger techniques:
+//! 1. Inductive checking (fastest, but may fail for non-inductive invariants)
+//! 2. k-induction with increasing K (2..5)
+//! 3. IC3/CHC via Spacer (unbounded, most powerful)
+//! 4. BMC fallback (bounded, catches real bugs)
+
+use crate::{SymbolicOutcome, SymbolicResult};
+use specl_eval::Value;
+use specl_ir::CompiledSpec;
+use tracing::info;
+
+/// Run smart mode: try increasingly powerful strategies.
+pub fn check_smart(
+    spec: &CompiledSpec,
+    consts: &[Value],
+    bmc_depth: usize,
+) -> SymbolicResult<SymbolicOutcome> {
+    // 1. Try simple induction
+    info!("smart: trying inductive checking");
+    match crate::inductive::check_inductive(spec, consts)? {
+        SymbolicOutcome::Ok { .. } => {
+            return Ok(SymbolicOutcome::Ok {
+                method: "smart(inductive)",
+            });
+        }
+        SymbolicOutcome::InvariantViolation { .. } => {
+            // Inductive failure = CTI (counterexample to induction), not a real bug
+            info!("smart: inductive check found CTI, trying k-induction");
+        }
+        SymbolicOutcome::Unknown { .. } => {
+            info!("smart: inductive check returned unknown, trying k-induction");
+        }
+    }
+
+    // 2. Try k-induction with increasing K
+    for k in [2, 3, 4, 5] {
+        info!(k, "smart: trying k-induction");
+        match crate::k_induction::check_k_induction(spec, consts, k)? {
+            SymbolicOutcome::Ok { .. } => {
+                return Ok(SymbolicOutcome::Ok {
+                    method: "smart(k-induction)",
+                });
+            }
+            SymbolicOutcome::InvariantViolation { invariant, trace } => {
+                // k-induction base case failure = real bug
+                return Ok(SymbolicOutcome::InvariantViolation { invariant, trace });
+            }
+            SymbolicOutcome::Unknown { .. } => {
+                // Inductive step failed at this K, try higher
+            }
+        }
+    }
+
+    // 3. Try IC3/CHC
+    info!("smart: trying IC3/CHC");
+    match crate::ic3::check_ic3(spec, consts)? {
+        SymbolicOutcome::Ok { .. } => {
+            return Ok(SymbolicOutcome::Ok {
+                method: "smart(IC3)",
+            });
+        }
+        SymbolicOutcome::InvariantViolation { invariant, trace } => {
+            return Ok(SymbolicOutcome::InvariantViolation { invariant, trace });
+        }
+        SymbolicOutcome::Unknown { .. } => {
+            info!("smart: IC3 returned unknown, falling back to BMC");
+        }
+    }
+
+    // 4. Fall back to BMC
+    info!(depth = bmc_depth, "smart: falling back to BMC");
+    match crate::bmc::check_bmc(spec, consts, bmc_depth)? {
+        SymbolicOutcome::Ok { .. } => Ok(SymbolicOutcome::Ok {
+            method: "smart(BMC)",
+        }),
+        other => Ok(other),
+    }
+}

--- a/specl/crates/specl-symbolic/src/trace.rs
+++ b/specl/crates/specl-symbolic/src/trace.rs
@@ -1,10 +1,11 @@
 //! Counterexample trace extraction from Z3 models.
 
+use crate::encoder::EncoderCtx;
 use crate::state_vars::{VarKind, VarLayout};
 use crate::TraceStep;
 use specl_eval::Value;
 use specl_ir::CompiledSpec;
-use z3::ast::Dynamic;
+use z3::ast::{Dynamic, Int};
 use z3::Model;
 
 /// Extract a counterexample trace from a Z3 model.
@@ -12,19 +13,134 @@ pub fn extract_trace(
     model: &Model,
     layout: &VarLayout,
     step_vars: &[Vec<Vec<Dynamic>>],
-    _spec: &CompiledSpec,
-    _consts: &[Value],
+    spec: &CompiledSpec,
+    consts: &[Value],
     depth: usize,
 ) -> Vec<TraceStep> {
     let mut trace = Vec::new();
 
     for step in 0..=depth {
         let state = extract_state(model, layout, &step_vars[step]);
-        let action = None; // Action identification is a future improvement
+        let action = if step > 0 {
+            identify_action(model, layout, step_vars, spec, consts, step - 1)
+        } else {
+            Some("init".to_string())
+        };
         trace.push(TraceStep { state, action });
     }
 
     trace
+}
+
+/// Identify which action fired at the given step by evaluating guards against the model.
+fn identify_action(
+    model: &Model,
+    layout: &VarLayout,
+    step_vars: &[Vec<Vec<Dynamic>>],
+    spec: &CompiledSpec,
+    consts: &[Value],
+    step: usize,
+) -> Option<String> {
+    for action in &spec.actions {
+        let param_ranges: Vec<(i64, i64)> = action
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (_, ty))| {
+                use specl_types::Type;
+                match ty {
+                    Type::Range(lo, hi) => Some((*lo, *hi)),
+                    Type::Int => action
+                        .param_type_exprs
+                        .get(i)
+                        .and_then(|te| crate::state_vars::eval_type_expr_range(te, spec, consts)),
+                    _ => None,
+                }
+            })
+            .collect();
+
+        if param_ranges.len() != action.params.len() {
+            continue;
+        }
+
+        if param_ranges.is_empty() {
+            // No parameters — just evaluate the guard
+            if guard_satisfied(model, layout, step_vars, spec, consts, action, step, &[]) {
+                return Some(action.name.clone());
+            }
+        } else {
+            // Try each parameter combination
+            let mut combos = Vec::new();
+            enumerate_param_combos(&param_ranges, 0, &mut Vec::new(), &mut combos);
+            for combo in &combos {
+                if guard_satisfied(model, layout, step_vars, spec, consts, action, step, combo) {
+                    let params_str = combo
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Some(format!("{}({})", action.name, params_str));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Check if an action's guard is satisfied in the model at the given step.
+fn guard_satisfied(
+    model: &Model,
+    layout: &VarLayout,
+    step_vars: &[Vec<Vec<Dynamic>>],
+    _spec: &CompiledSpec,
+    consts: &[Value],
+    action: &specl_ir::CompiledAction,
+    step: usize,
+    params: &[i64],
+) -> bool {
+    let z3_params: Vec<Dynamic> = params
+        .iter()
+        .map(|v| Dynamic::from_ast(&Int::from_i64(*v)))
+        .collect();
+
+    let mut enc = EncoderCtx {
+        layout,
+        consts,
+        step_vars,
+        current_step: step,
+        next_step: step + 1,
+        params: &z3_params,
+        locals: Vec::new(),
+    };
+
+    let Ok(guard) = enc.encode_bool(&action.guard) else {
+        return false;
+    };
+
+    model
+        .eval(&Dynamic::from_ast(&guard), true)
+        .and_then(|v| v.as_bool())
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false)
+}
+
+fn enumerate_param_combos(
+    ranges: &[(i64, i64)],
+    depth: usize,
+    current: &mut Vec<i64>,
+    result: &mut Vec<Vec<i64>>,
+) {
+    if depth == ranges.len() {
+        result.push(current.clone());
+        return;
+    }
+    let (lo, hi) = ranges[depth];
+    for v in lo..=hi {
+        current.push(v);
+        enumerate_param_combos(ranges, depth + 1, current, result);
+        current.pop();
+    }
 }
 
 fn extract_state(
@@ -47,9 +163,13 @@ fn extract_state(
                 .eval(&z3_vars[0], true)
                 .and_then(|v| v.as_int())
                 .and_then(|i| i.as_i64())
-                .map(|n| n.to_string())
+                .map(|n| format_int_value(n, &entry.kind, &layout.string_table))
                 .unwrap_or_else(|| "?".to_string()),
-            VarKind::ExplodedDict { key_lo, key_hi, .. } => {
+            VarKind::ExplodedDict {
+                key_lo,
+                key_hi,
+                value_kind,
+            } => {
                 let mut pairs = Vec::new();
                 for (i, k) in (*key_lo..=*key_hi).enumerate() {
                     let val = model
@@ -57,7 +177,7 @@ fn extract_state(
                         .and_then(|v| {
                             v.as_int()
                                 .and_then(|i| i.as_i64())
-                                .map(|n| n.to_string())
+                                .map(|n| format_int_value(n, value_kind, &layout.string_table))
                                 .or_else(|| {
                                     v.as_bool().and_then(|b| b.as_bool()).map(|b| b.to_string())
                                 })
@@ -87,4 +207,20 @@ fn extract_state(
     }
 
     state
+}
+
+/// Format an integer value, using string table reverse-lookup if applicable.
+fn format_int_value(n: i64, kind: &VarKind, string_table: &[String]) -> String {
+    if let VarKind::Int {
+        lo: Some(0),
+        hi: Some(hi),
+    } = kind
+    {
+        if !string_table.is_empty() && *hi == string_table.len() as i64 - 1 {
+            if let Some(s) = string_table.get(n as usize) {
+                return format!("\"{}\"", s);
+            }
+        }
+    }
+    n.to_string()
 }


### PR DESCRIPTION
## Summary

Complete symbolic model checking phase 2, adding all remaining verification modes and encoding capabilities:

- **Set operations** (union/intersect/diff/subset) for ExplodedSet encoding — enables TwoPhaseCommit
- **String variable encoding** via string table interning — enables TCommit_Simple
- **Const-dependent type inference** from AST type expressions (resolves `0..MAX` when MAX is a const)
- **k-induction** (`--k-induction K`): base case BMC + K-step inductive strengthening
- **IC3/CHC** (`--ic3`): unbounded verification via Z3's Spacer engine, using raw z3-sys fixedpoint API with explicit forall quantification
- **Smart mode** (`--smart`): automatic strategy cascade (induction → k-induction K=2..5 → IC3 → BMC)
- **Trace action identification**: counterexample traces now show which action fired at each step
- **Fix**: k-induction CTI correctly returns Unknown instead of InvariantViolation

## Verification

- All 119 existing tests pass
- `cargo fmt --check` clean, zero warnings on specl-symbolic
- Counter: verified by all modes (inductive, k-induction K=3, IC3, smart)
- TCommit_Simple: verified by inductive, k-induction K=2, IC3, smart
- TwoPhaseCommit (MAX_RM=1): verified by BMC depth 5, IC3, smart(IC3)
- ProcessStates: verified by IC3

## Test plan

- [x] `cargo test --workspace --exclude specl-tla` — 119 tests pass
- [x] `cargo fmt --check` — clean
- [x] Counter: `--k-induction 3`, `--ic3`, `--smart` all OK
- [x] TCommit_Simple: `--ic3`, `--smart` all OK
- [x] TwoPhaseCommit: `--symbolic --depth 5`, `--ic3`, `--smart` all OK
- [x] Trace action identification shows correct action names with parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)