### PR TITLE
feat(symbolic): Seq, powerset, choose, keys/values, strings, compound dicts

### DIFF
--- a/specl/crates/specl-cli/src/main.rs
+++ b/specl/crates/specl-cli/src/main.rs
@@ -176,6 +176,10 @@ enum Commands {
         #[arg(long)]
         smart: bool,
 
+        /// Maximum sequence length for symbolic Seq[T] variables (default: 5)
+        #[arg(long, default_value = "5")]
+        seq_bound: usize,
+
         /// Show verbose output
         #[arg(short, long)]
         verbose: bool,
@@ -279,10 +283,20 @@ fn main() {
             k_induction,
             ic3,
             smart,
+            seq_bound,
             verbose,
         } => {
             if symbolic || inductive || k_induction.is_some() || ic3 || smart {
-                cmd_check_symbolic(&file, &constant, depth, inductive, k_induction, ic3, smart)
+                cmd_check_symbolic(
+                    &file,
+                    &constant,
+                    depth,
+                    inductive,
+                    k_induction,
+                    ic3,
+                    smart,
+                    seq_bound,
+                )
             } else {
                 cmd_check(
                     &file,
@@ -505,6 +519,7 @@ fn cmd_check_symbolic(
     k_induction: Option<usize>,
     ic3: bool,
     smart: bool,
+    seq_bound: usize,
 ) -> CliResult<()> {
     let filename = file.display().to_string();
     let source = Arc::new(fs::read_to_string(file).map_err(|e| CliError::IoError {
@@ -539,6 +554,7 @@ fn cmd_check_symbolic(
             SymbolicMode::Bmc
         },
         depth,
+        seq_bound,
     };
 
     let mode_str = if smart {

--- a/specl/crates/specl-symbolic/src/bmc.rs
+++ b/specl/crates/specl-symbolic/src/bmc.rs
@@ -15,10 +15,11 @@ pub fn check_bmc(
     spec: &CompiledSpec,
     consts: &[Value],
     max_depth: usize,
+    seq_bound: usize,
 ) -> SymbolicResult<SymbolicOutcome> {
     info!(depth = max_depth, "starting symbolic BMC");
 
-    let layout = VarLayout::from_spec(spec, consts)?;
+    let layout = VarLayout::from_spec(spec, consts, seq_bound)?;
     let solver = Solver::new();
 
     // Create Z3 variables for steps 0..=max_depth
@@ -54,6 +55,8 @@ pub fn check_bmc(
                 next_step: k,
                 params: &[],
                 locals: Vec::new(),
+                compound_locals: Vec::new(),
+                set_locals: Vec::new(),
             };
 
             let inv_encoded = enc.encode_bool(&inv.body)?;

--- a/specl/crates/specl-symbolic/src/inductive.rs
+++ b/specl/crates/specl-symbolic/src/inductive.rs
@@ -17,10 +17,14 @@ use z3::{SatResult, Solver};
 ///
 /// If UNSAT, I is inductive and holds for all reachable states.
 /// If SAT, I is not inductive — the model gives a counterexample to induction (CTI).
-pub fn check_inductive(spec: &CompiledSpec, consts: &[Value]) -> SymbolicResult<SymbolicOutcome> {
+pub fn check_inductive(
+    spec: &CompiledSpec,
+    consts: &[Value],
+    seq_bound: usize,
+) -> SymbolicResult<SymbolicOutcome> {
     info!("starting inductive invariant checking");
 
-    let layout = VarLayout::from_spec(spec, consts)?;
+    let layout = VarLayout::from_spec(spec, consts, seq_bound)?;
     let solver = Solver::new();
 
     let step0_vars = create_step_vars(&layout, 0);
@@ -44,6 +48,8 @@ pub fn check_inductive(spec: &CompiledSpec, consts: &[Value]) -> SymbolicResult<
             next_step: 0,
             params: &[],
             locals: Vec::new(),
+            compound_locals: Vec::new(),
+            set_locals: Vec::new(),
         };
         let inv_at_0 = enc0.encode_bool(&inv.body)?;
         solver.assert(&inv_at_0);
@@ -56,6 +62,8 @@ pub fn check_inductive(spec: &CompiledSpec, consts: &[Value]) -> SymbolicResult<
             next_step: 1,
             params: &[],
             locals: Vec::new(),
+            compound_locals: Vec::new(),
+            set_locals: Vec::new(),
         };
         let inv_at_1 = enc1.encode_bool(&inv.body)?;
         solver.assert(&inv_at_1.not());

--- a/specl/crates/specl-symbolic/src/k_induction.rs
+++ b/specl/crates/specl-symbolic/src/k_induction.rs
@@ -22,10 +22,11 @@ pub fn check_k_induction(
     spec: &CompiledSpec,
     consts: &[Value],
     k: usize,
+    seq_bound: usize,
 ) -> SymbolicResult<SymbolicOutcome> {
     info!(k, "starting k-induction");
 
-    let layout = VarLayout::from_spec(spec, consts)?;
+    let layout = VarLayout::from_spec(spec, consts, seq_bound)?;
 
     // === Base case: BMC to depth K ===
     info!(k, "k-induction base case");
@@ -75,6 +76,8 @@ fn check_base_case(
                 next_step: depth,
                 params: &[],
                 locals: Vec::new(),
+                compound_locals: Vec::new(),
+                set_locals: Vec::new(),
             };
             let inv_encoded = enc.encode_bool(&inv.body)?;
             solver.assert(&inv_encoded.not());
@@ -146,6 +149,8 @@ fn check_inductive_step(
                 next_step: step,
                 params: &[],
                 locals: Vec::new(),
+                compound_locals: Vec::new(),
+                set_locals: Vec::new(),
             };
             let inv_at_step = enc.encode_bool(&inv.body)?;
             solver.assert(&inv_at_step);
@@ -160,6 +165,8 @@ fn check_inductive_step(
             next_step: k,
             params: &[],
             locals: Vec::new(),
+            compound_locals: Vec::new(),
+            set_locals: Vec::new(),
         };
         let inv_at_k = enc_k.encode_bool(&inv.body)?;
         solver.assert(&inv_at_k.not());

--- a/specl/crates/specl-symbolic/src/lib.rs
+++ b/specl/crates/specl-symbolic/src/lib.rs
@@ -64,6 +64,8 @@ pub struct TraceStep {
 pub struct SymbolicConfig {
     pub mode: SymbolicMode,
     pub depth: usize,
+    /// Maximum sequence length for Seq[T] variables (default: 5).
+    pub seq_bound: usize,
 }
 
 /// Symbolic checking mode.
@@ -87,11 +89,12 @@ pub fn check(
     consts: &[Value],
     config: &SymbolicConfig,
 ) -> SymbolicResult<SymbolicOutcome> {
+    let sb = config.seq_bound;
     match config.mode {
-        SymbolicMode::Bmc => bmc::check_bmc(spec, consts, config.depth),
-        SymbolicMode::Inductive => inductive::check_inductive(spec, consts),
-        SymbolicMode::KInduction(k) => k_induction::check_k_induction(spec, consts, k),
-        SymbolicMode::Ic3 => ic3::check_ic3(spec, consts),
-        SymbolicMode::Smart => smart::check_smart(spec, consts, config.depth),
+        SymbolicMode::Bmc => bmc::check_bmc(spec, consts, config.depth, sb),
+        SymbolicMode::Inductive => inductive::check_inductive(spec, consts, sb),
+        SymbolicMode::KInduction(k) => k_induction::check_k_induction(spec, consts, k, sb),
+        SymbolicMode::Ic3 => ic3::check_ic3(spec, consts, sb),
+        SymbolicMode::Smart => smart::check_smart(spec, consts, config.depth, sb),
     }
 }

--- a/specl/crates/specl-symbolic/src/smart.rs
+++ b/specl/crates/specl-symbolic/src/smart.rs
@@ -16,10 +16,11 @@ pub fn check_smart(
     spec: &CompiledSpec,
     consts: &[Value],
     bmc_depth: usize,
+    seq_bound: usize,
 ) -> SymbolicResult<SymbolicOutcome> {
     // 1. Try simple induction
     info!("smart: trying inductive checking");
-    match crate::inductive::check_inductive(spec, consts)? {
+    match crate::inductive::check_inductive(spec, consts, seq_bound)? {
         SymbolicOutcome::Ok { .. } => {
             return Ok(SymbolicOutcome::Ok {
                 method: "smart(inductive)",
@@ -37,7 +38,7 @@ pub fn check_smart(
     // 2. Try k-induction with increasing K
     for k in [2, 3, 4, 5] {
         info!(k, "smart: trying k-induction");
-        match crate::k_induction::check_k_induction(spec, consts, k)? {
+        match crate::k_induction::check_k_induction(spec, consts, k, seq_bound)? {
             SymbolicOutcome::Ok { .. } => {
                 return Ok(SymbolicOutcome::Ok {
                     method: "smart(k-induction)",
@@ -55,7 +56,7 @@ pub fn check_smart(
 
     // 3. Try IC3/CHC
     info!("smart: trying IC3/CHC");
-    match crate::ic3::check_ic3(spec, consts)? {
+    match crate::ic3::check_ic3(spec, consts, seq_bound)? {
         SymbolicOutcome::Ok { .. } => {
             return Ok(SymbolicOutcome::Ok {
                 method: "smart(IC3)",
@@ -71,7 +72,7 @@ pub fn check_smart(
 
     // 4. Fall back to BMC
     info!(depth = bmc_depth, "smart: falling back to BMC");
-    match crate::bmc::check_bmc(spec, consts, bmc_depth)? {
+    match crate::bmc::check_bmc(spec, consts, bmc_depth, seq_bound)? {
         SymbolicOutcome::Ok { .. } => Ok(SymbolicOutcome::Ok {
             method: "smart(BMC)",
         }),


### PR DESCRIPTION
## Summary

- **Seq[T] encoding**: `ExplodedSeq` VarKind with `[len, elem_0..elem_n]` Z3 layout, `--seq-bound` CLI flag, head/tail/concat/slice/index operations, init and effect encoding
- **Dict[Range, Seq[T]]**: stride-based compound encoding with symbolic key support via ITE chains, compound locals for function inlining, If-then-else in dict merge updates
- **Powerset quantification**: bitmask enumeration over all 2^n subsets with set-local tracking
- **Choose expression**: ITE chain over domain with predicate
- **Keys/Values**: membership and length encoding for dict variables
- **String gaps**: `Value::String` in constants, `Type::String` action parameters and trace extraction
- **Clear error messages**: specific messages for Tuple, Record, Option, Powerset-as-value, BigUnion, Fix, temporal operators, action calls

### Specs now passing symbolic checking

Counter, SeqTest, Transfer, DieHard, DiningPhilosophers, ProcessStates, DistributedCounter, TrafficLight, Bunny1, Bunny2, BankingRecords, SimpleQueue, RaftMongo, TCommit_Simple, EWD840, ChainReplication, ChandyLamport, MESI

### Known remaining limitations (clear error messages)

- Nested dicts (`Dict[Int, Dict[Int, Bool]]`) — Paxos, Comet, PBFT
- Set as container value — Redlock
- Set-typed action parameters

## Test plan

- [x] `cargo test --workspace --exclude specl-tla` — all 125 tests pass
- [x] `cargo fmt --check` clean, zero warnings on specl-symbolic
- [x] Regression: Counter, SeqTest, SimpleQueue, RaftMongo, ChainReplication, EWD840, TCommit_Simple
- [x] New: ChandyLamport (Dict[Int, Seq[Int]] with if-then-else), Bunny1/2, BankingRecords, MESI, DiningPhilosophers
- [x] Powerset: custom voting specs with majority quorum patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)